### PR TITLE
fix dynamic import warning

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,10 +1,10 @@
-import { MdxContent } from '@/app/_lib/MdxContent';
 import { DAYJS_DEFAULT_FORMAT, POSTS_PATH } from '@/constants';
 import dayjs from 'dayjs';
 import fs from 'fs';
 import type { ResolvedMetadata, ResolvingMetadata } from 'next';
 import { MDXRemoteSerializeResult } from 'next-mdx-remote';
 import { serialize } from 'next-mdx-remote/serialize';
+import dynamic from 'next/dynamic';
 import path from 'path';
 import remarkGfm from 'remark-gfm';
 import { twMerge } from 'tailwind-merge';
@@ -40,6 +40,10 @@ export default async function PostPage({
 }) {
   const { serialized, frontmatter } = await getPost({
     slug: params.slug,
+  });
+
+  const MdxContent = dynamic(() => import('@/app/_lib/MdxContent').then((mod) => mod.MdxContent), {
+    ssr: false,
   });
 
   return (


### PR DESCRIPTION
```
Instead change the require of index.js in /Users/aquibbaig/Desktop/code/site/.next/server/app/blog/[slug]/page.js to a dynamic import() which is available in all CommonJS modules.
    at next-mdx-remote (/Users/aquibbaig/Desktop/code/site/.next/server/app/blog/[slug]/page.js:99:18)
    at __webpack_require__ (/Users/aquibbaig/Desktop/code/site/.next/server/webpack-runtime.js:33:43)
    at eval (./src/app/_lib/MdxContent.tsx:7:73)
    at (ssr)/./src/app/_lib/MdxContent.tsx (/Users/aquibbaig/Desktop/code/site/.next/server/app/blog/[slug]/page.js:249:1)
    at Object.__webpack_require__ [as require] (/Users/aquibbaig/Desktop/code/site/.next/server/webpack-runtime.js:33:43)
digest: "607044995"
```

Fixes this cryptic error when trying to import a named component inside a next app router page. -_-